### PR TITLE
GRFN-824: Adjust TTL of temporary credentials

### DIFF
--- a/temporary-credentials/cloudformation.yaml
+++ b/temporary-credentials/cloudformation.yaml
@@ -104,7 +104,7 @@ Resources:
               "temporary_credentials": {
                 "credentials": {
                     "role_arn": "${AccessRole.Arn}",
-                    "duration_seconds": 900
+                    "duration_seconds": 43200
                 },
                 "policy": {
                     "role_name": "${AccessRole}",


### PR DESCRIPTION
Set temporary credential TTL to 12 hours -- 12*3600 seconds.