### PR TITLE
integrate grfn-test with production earthdata login

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           - environment: grfn-test
             stack_name: distribution-test
             domain: grfn-test.asf.alaska.edu
-            auth_url: "https://uat.urs.earthdata.nasa.gov/oauth/authorize?client_id=Qkd0Z9KbhG86qedkRC7nSA&response_type=code&redirect_uri=https://auth-test-jenk.asf.alaska.edu/login"
+            auth_url: "https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g&redirect_uri=https://auth.asf.alaska.edu/login"
             jwt_cookie_name: asf-urs
             log_bucket: grfn-logs
             private_bucket: grfn-content-test


### PR DESCRIPTION
https://auth-test-jenk.asf.alaska.edu is no longer a functioning deployment of the ASF authentication API, meaning products cannot be downloaded from our test deployment, e.g. https://grfn-test.asf.alaska.edu/door/download/S1-GUNW-A-R-106-tops-20230721_20220702-230048-00078W_00043N-PP-e971-v3_0_0.nc

This PR integrates grfn-test.alaska.edu with the production authentication API at auth.asf.alaska.edu, and with production Earthdata Login rather than UAT.

TODO:
  - [x] update the JWT_PUBLIC_KEY github secret for the grfn-test environment.