### PR TITLE
resolve issue installing cryptography for aws lambda environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "bumpless"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "bumpless"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,8 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r door/requirements.txt -t door/src/
+          python -m pip install -r requirements-door.txt -t door/src/
+          python -m pip install -r requirements-door-binary.txt --platform manylinux2014_x86_64 --only-binary=:all: -t door/src/
 
       - name: package and deploy
         if: github.ref == matrix.deploy_ref

--- a/door/requirements.txt
+++ b/door/requirements.txt
@@ -1,6 +1,0 @@
-Flask
-Flask-Cors
-rsa
-serverless_wsgi
-PyJWT
-cryptography

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,6 +1,0 @@
--r door/requirements.txt
-boto3
-flake8
-flake8-blind-except
-flake8-builtins
-flake8-import-order

--- a/requirements-door-binary.txt
+++ b/requirements-door-binary.txt
@@ -1,0 +1,1 @@
+cryptography==41.0.3

--- a/requirements-door.txt
+++ b/requirements-door.txt
@@ -1,0 +1,6 @@
+boto3=1.28.32
+Flask==2.2.5
+Flask-Cors==4.0.0
+rsa==4.9
+serverless_wsgi==3.0.2
+PyJWT==2.8.0


### PR DESCRIPTION
It's been two years since we touched this repository, so today's deployment failed due to python dependency issues. The `door` lambda now fails in the test environment with `Runtime.ImportModuleError: Unable to import module 'door.lambda_handler': /lib64/libc.so.6: version GLIBC_2.28 not found (required by /var/task/cryptography/hazmat/bindings/_rust.abi3.so)`

This PR freezes package versions, enables dependabot, and resolves installation of cryptography for aws lambda environments using the same approach as https://github.com/ASFHyP3/hyp3